### PR TITLE
Refactor robot module

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ pybullet = "*"
 numba = "*"
 scipy = "*"
 zmq = "*"
+matplotlib = "*"
 pybullet-controllers = {path = "./src/pybullet_controllers"}
 pybullet-simulation = {path = "./src/pybullet_simulation"}
 pybullet-interfaces = {path = "./src/pybullet_interfaces"}
@@ -24,3 +25,4 @@ python_version = "3.8"
 simple_ctrl_test = "python3 demos/simple_ctrl_test.py"
 hyb_ctrl_test = "python3 demos/hyb_ctrl_test.py"
 zmq_interface_test = "python3 tests/interface_test.py"
+zmq_velocity_control = "python3 tests/velocity_control_test.py"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9c1f807bebd090054753eaa53e10f3025fae0a7ae4dfe0d3c7dd941200dee004"
+            "sha256": "a4df38521cde001abdcec5671a571ebb05e1cf96a64ae5052f191ee820016e88"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,51 @@
         ]
     },
     "default": {
+        "cycler": {
+            "hashes": [
+                "sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d",
+                "sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8"
+            ],
+            "version": "==0.10.0"
+        },
+        "kiwisolver": {
+            "hashes": [
+                "sha256:0cd53f403202159b44528498de18f9285b04482bab2a6fc3f5dd8dbb9352e30d",
+                "sha256:1e1bc12fb773a7b2ffdeb8380609f4f8064777877b2225dec3da711b421fda31",
+                "sha256:225e2e18f271e0ed8157d7f4518ffbf99b9450fca398d561eb5c4a87d0986dd9",
+                "sha256:232c9e11fd7ac3a470d65cd67e4359eee155ec57e822e5220322d7b2ac84fbf0",
+                "sha256:31dfd2ac56edc0ff9ac295193eeaea1c0c923c0355bf948fbd99ed6018010b72",
+                "sha256:33449715e0101e4d34f64990352bce4095c8bf13bed1b390773fc0a7295967b3",
+                "sha256:401a2e9afa8588589775fe34fc22d918ae839aaaf0c0e96441c0fdbce6d8ebe6",
+                "sha256:44a62e24d9b01ba94ae7a4a6c3fb215dc4af1dde817e7498d901e229aaf50e4e",
+                "sha256:50af681a36b2a1dee1d3c169ade9fdc59207d3c31e522519181e12f1b3ba7000",
+                "sha256:563c649cfdef27d081c84e72a03b48ea9408c16657500c312575ae9d9f7bc1c3",
+                "sha256:5989db3b3b34b76c09253deeaf7fbc2707616f130e166996606c284395da3f18",
+                "sha256:5a7a7dbff17e66fac9142ae2ecafb719393aaee6a3768c9de2fd425c63b53e21",
+                "sha256:5c3e6455341008a054cccee8c5d24481bcfe1acdbc9add30aa95798e95c65621",
+                "sha256:5f6ccd3dd0b9739edcf407514016108e2280769c73a85b9e59aa390046dbf08b",
+                "sha256:72c99e39d005b793fb7d3d4e660aed6b6281b502e8c1eaf8ee8346023c8e03bc",
+                "sha256:78751b33595f7f9511952e7e60ce858c6d64db2e062afb325985ddbd34b5c131",
+                "sha256:834ee27348c4aefc20b479335fd422a2c69db55f7d9ab61721ac8cd83eb78882",
+                "sha256:8be8d84b7d4f2ba4ffff3665bcd0211318aa632395a1a41553250484a871d454",
+                "sha256:950a199911a8d94683a6b10321f9345d5a3a8433ec58b217ace979e18f16e248",
+                "sha256:a357fd4f15ee49b4a98b44ec23a34a95f1e00292a139d6015c11f55774ef10de",
+                "sha256:a53d27d0c2a0ebd07e395e56a1fbdf75ffedc4a05943daf472af163413ce9598",
+                "sha256:acef3d59d47dd85ecf909c359d0fd2c81ed33bdff70216d3956b463e12c38a54",
+                "sha256:b38694dcdac990a743aa654037ff1188c7a9801ac3ccc548d3341014bc5ca278",
+                "sha256:b9edd0110a77fc321ab090aaa1cfcaba1d8499850a12848b81be2222eab648f6",
+                "sha256:c08e95114951dc2090c4a630c2385bef681cacf12636fb0241accdc6b303fd81",
+                "sha256:c5518d51a0735b1e6cee1fdce66359f8d2b59c3ca85dc2b0813a8aa86818a030",
+                "sha256:c8fd0f1ae9d92b42854b2979024d7597685ce4ada367172ed7c09edf2cef9cb8",
+                "sha256:ca3820eb7f7faf7f0aa88de0e54681bddcb46e485beb844fcecbcd1c8bd01689",
+                "sha256:cf8b574c7b9aa060c62116d4181f3a1a4e821b2ec5cbfe3775809474113748d4",
+                "sha256:d3155d828dec1d43283bd24d3d3e0d9c7c350cdfcc0bd06c0ad1209c1bbc36d0",
+                "sha256:f8d6f8db88049a699817fd9178782867bf22283e3813064302ac59f61d95be05",
+                "sha256:fd34fbbfbc40628200730bc1febe30631347103fc8d3d4fa012c21ab9c11eca9"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.3.1"
+        },
         "llvmlite": {
             "hashes": [
                 "sha256:048a7c117641c9be87b90005684e64a6f33ea0897ebab1df8a01214a10d6e79a",
@@ -42,6 +87,31 @@
             ],
             "markers": "python_version < '3.10' and python_version >= '3.6'",
             "version": "==0.36.0"
+        },
+        "matplotlib": {
+            "hashes": [
+                "sha256:133469eb5d54a0a963d08a07356d03f6de41b6789f2a9d15aed0e6f3aabbf502",
+                "sha256:2b54bbce73115f6f95912f57348b2e0fc03cc86a09c73191f1216d79c16cda3c",
+                "sha256:36e2f68b7d2f22eacc4d9d4dfdf3a975c9db31fa6e36e16a2d60bf4c1ff5a35c",
+                "sha256:3847ce29a01e1d1f0aa691263e510ce8504a20d158a811ed3a45c4c1d9e708e7",
+                "sha256:3bcee5685afb76d2a31f8a6b190caf2e52be250d214155b91830110416767de3",
+                "sha256:3c617fc6f7d6ac0c6142e34f3066520273195c75fb5371eabfddb3da04a75174",
+                "sha256:4002b0928bcd695eb7f23bf18c52e3cf23501a9c06a1de596079d74932aa4068",
+                "sha256:424ddb3422c65b284a38a97eb48f5cb64b66a44a773e0c71281a347f1738f146",
+                "sha256:7571d470cd5df2d6c27ee0e6dabbebd130eae91da19c3749c6946918f8bcad49",
+                "sha256:7e76956b8dd4bd8a6be71e401e4a24d975e57d5849a80c24a35551040ff82df0",
+                "sha256:85388289b356f5f19464b84eaa7532cd10d3f701505ae8d988b3dfb1332d785f",
+                "sha256:85d7b8da66bb71054f3d73210b4fe24cca8afc6f92f00569b2ad24ca32438034",
+                "sha256:8b046715f710b58dc89241eb3c8e907a30b269e915df6a134bb419f05a6507bf",
+                "sha256:966a1bb53ce56dcd542b4edb667166aac14c8eaf2a3acd68f403eccedf0d21a7",
+                "sha256:a2828982c5329cceea67bae0af49e2bfae3471499d6d6aa4359efa0ef491b0f7",
+                "sha256:a960ee5a139011e1d203df75eafc4e98013927f36ab69510313bc7d9d4641e38",
+                "sha256:e879b5915f0c8e765d0e1ae4ecf93fafbde4a1dee88409427ac0ca55d31a41a9",
+                "sha256:fa0f7f3b2a0067ee5806264478f39fa52d7ddf8ee9b3012e5257b2ff39a15e0b",
+                "sha256:fe4676d7f25d2915562aa551996843e97e7d25aefc54617a3b0fe74a967bc2c8"
+            ],
+            "index": "pypi",
+            "version": "==3.4.0"
         },
         "numba": {
             "hashes": [
@@ -135,6 +205,45 @@
             "index": "pypi",
             "version": "==2021.3.17.16.51.43"
         },
+        "pillow": {
+            "hashes": [
+                "sha256:15306d71a1e96d7e271fd2a0737038b5a92ca2978d2e38b6ced7966583e3d5af",
+                "sha256:1940fc4d361f9cc7e558d6f56ff38d7351b53052fd7911f4b60cd7bc091ea3b1",
+                "sha256:1f93f2fe211f1ef75e6f589327f4d4f8545d5c8e826231b042b483d8383e8a7c",
+                "sha256:30d33a1a6400132e6f521640dd3f64578ac9bfb79a619416d7e8802b4ce1dd55",
+                "sha256:328240f7dddf77783e72d5ed79899a6b48bc6681f8d1f6001f55933cb4905060",
+                "sha256:46c2bcf8e1e75d154e78417b3e3c64e96def738c2a25435e74909e127a8cba5e",
+                "sha256:5762ebb4436f46b566fc6351d67a9b5386b5e5de4e58fdaa18a1c83e0e20f1a8",
+                "sha256:5a2d957eb4aba9d48170b8fe6538ec1fbc2119ffe6373782c03d8acad3323f2e",
+                "sha256:5cf03b9534aca63b192856aa601c68d0764810857786ea5da652581f3a44c2b0",
+                "sha256:5daba2b40782c1c5157a788ec4454067c6616f5a0c1b70e26ac326a880c2d328",
+                "sha256:63cd413ac52ee3f67057223d363f4f82ce966e64906aea046daf46695e3c8238",
+                "sha256:6efac40344d8f668b6c4533ae02a48d52fd852ef0654cc6f19f6ac146399c733",
+                "sha256:71b01ee69e7df527439d7752a2ce8fb89e19a32df484a308eca3e81f673d3a03",
+                "sha256:71f31ee4df3d5e0b366dd362007740106d3210fb6a56ec4b581a5324ba254f06",
+                "sha256:72027ebf682abc9bafd93b43edc44279f641e8996fb2945104471419113cfc71",
+                "sha256:74cd9aa648ed6dd25e572453eb09b08817a1e3d9f8d1bd4d8403d99e42ea790b",
+                "sha256:81b3716cc9744ffdf76b39afb6247eae754186838cedad0b0ac63b2571253fe6",
+                "sha256:8565355a29655b28fdc2c666fd9a3890fe5edc6639d128814fafecfae2d70910",
+                "sha256:87f42c976f91ca2fc21a3293e25bd3cd895918597db1b95b93cbd949f7d019ce",
+                "sha256:89e4c757a91b8c55d97c91fa09c69b3677c227b942fa749e9a66eef602f59c28",
+                "sha256:8c4e32218c764bc27fe49b7328195579581aa419920edcc321c4cb877c65258d",
+                "sha256:903293320efe2466c1ab3509a33d6b866dc850cfd0c5d9cc92632014cec185fb",
+                "sha256:90882c6f084ef68b71bba190209a734bf90abb82ab5e8f64444c71d5974008c6",
+                "sha256:98afcac3205d31ab6a10c5006b0cf040d0026a68ec051edd3517b776c1d78b09",
+                "sha256:a01da2c266d9868c4f91a9c6faf47a251f23b9a862dce81d2ff583135206f5be",
+                "sha256:aeab4cd016e11e7aa5cfc49dcff8e51561fa64818a0be86efa82c7038e9369d0",
+                "sha256:b07c660e014852d98a00a91adfbe25033898a9d90a8f39beb2437d22a203fc44",
+                "sha256:bead24c0ae3f1f6afcb915a057943ccf65fc755d11a1410a909c1fefb6c06ad1",
+                "sha256:d1d6bca39bb6dd94fba23cdb3eeaea5e30c7717c5343004d900e2a63b132c341",
+                "sha256:e2cd8ac157c1e5ae88b6dd790648ee5d2777e76f1e5c7d184eaddb2938594f34",
+                "sha256:e5739ae63636a52b706a0facec77b2b58e485637e1638202556156e424a02dc2",
+                "sha256:f36c3ff63d6fc509ce599a2f5b0d0732189eed653420e7294c039d342c6e204a",
+                "sha256:f91b50ad88048d795c0ad004abbe1390aa1882073b1dca10bfd55d0b8cf18ec5"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.1.2"
+        },
         "pybullet": {
             "hashes": [
                 "sha256:03c1577b9616eab626c353108ddf746bb56da435a858a4691856cfd49c6b22b2",
@@ -164,6 +273,22 @@
         "pybullet-simulation": {
             "path": "./src/pybullet_simulation",
             "version": "==0.1"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.1"
         },
         "pyzmq": {
             "hashes": [
@@ -227,6 +352,14 @@
             ],
             "index": "pypi",
             "version": "==1.6.2"
+        },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.15.0"
         },
         "zmq": {
             "hashes": [

--- a/demos/hyb_ctrl_test.py
+++ b/demos/hyb_ctrl_test.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     slow_rate = 100.
 
     state = robot.get_state()
-    goal_pos, goal_ori = state['ee_pos'], state['ee_ori']
+    goal_pos, goal_ori = state['ee_position'], state['ee_orientation']
 
     controller = OSHybridController(robot)
     robot.enable()
@@ -63,7 +63,7 @@ if __name__ == "__main__":
         now = time.time()
 
         state = robot.get_state()
-        ee_pos = state['ee_pos']
+        ee_pos = state['ee_position']
         wrench = robot.get_ft_sensor_wrench(robot.get_ft_sensor_joints()[-1], in_world_frame=True, ft_link='child')
         # print wrench
         if abs(wrench[2]) >= 10.:

--- a/demos/hyb_ctrl_test.py
+++ b/demos/hyb_ctrl_test.py
@@ -34,16 +34,14 @@ if __name__ == "__main__":
 
     robot = PandaArm(robot_description=os.path.join(os.path.dirname(__file__), os.pardir, "models/panda_arm.urdf"),
                      uid=simulation.uid)
-    timeout = time.time() + 2
-    while time.time() < timeout:
-        robot.tuck()
-        simulation.step()
 
     slow_rate = 100.
 
-    goal_pos, goal_ori = robot.ee_pose()
+    state = robot.get_state()
+    goal_pos, goal_ori = state['ee_pos'], state['ee_ori']
 
     controller = OSHybridController(robot)
+    robot.enable()
 
     print("started")
 
@@ -64,8 +62,9 @@ if __name__ == "__main__":
     while i < z_traj.size:
         now = time.time()
 
-        ee_pos, _ = robot.ee_pose()
-        wrench = robot.get_ee_wrench(local=False)
+        state = robot.get_state()
+        ee_pos = state['ee_pos']
+        wrench = robot.get_ft_sensor_wrench(robot.get_ft_sensor_joints()[-1], in_world_frame=True, ft_link='child')
         # print wrench
         if abs(wrench[2]) >= 10.:
             break

--- a/demos/simple_ctrl_test.py
+++ b/demos/simple_ctrl_test.py
@@ -16,16 +16,14 @@ if __name__ == "__main__":
 
     robot = PandaArm(robot_description=os.path.join(os.path.dirname(__file__), os.pardir, "models/panda_arm.urdf"),
                      uid=simulation.uid)
-    timeout = time.time() + 2
-    while time.time() < timeout:
-        robot.tuck()
-        simulation.step()
 
     slow_rate = 100.
 
-    goal_pos, goal_ori = robot.ee_pose()
+    state = robot.get_state()
+    goal_pos, goal_ori = state['ee_pos'], state['ee_ori']
 
     controller = OSImpedanceController(robot)
+    robot.enable()
 
     print("started")
 
@@ -38,12 +36,12 @@ if __name__ == "__main__":
     while i < z_traj.size:
         now = time.time()
 
-        ee_pos, _ = robot.ee_pose()
-        wrench = robot.get_ee_wrench(local=False)
+        state = robot.get_state()
+        ee_pos = state['ee_pos']
 
         goal_pos[2] = z_traj[i]
 
-        print("Goal:", ee_pos, "Actual:", goal_pos)
+        print("Goal:", goal_pos, "Actual:", ee_pos)
         controller.update_goal(goal_pos, goal_ori)
 
         elapsed = time.time() - now

--- a/demos/simple_ctrl_test.py
+++ b/demos/simple_ctrl_test.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
     slow_rate = 100.
 
     state = robot.get_state()
-    goal_pos, goal_ori = state['ee_pos'], state['ee_ori']
+    goal_pos, goal_ori = state['ee_position'], state['ee_orientation']
 
     controller = OSImpedanceController(robot)
     robot.enable()
@@ -37,7 +37,7 @@ if __name__ == "__main__":
         now = time.time()
 
         state = robot.get_state()
-        ee_pos = state['ee_pos']
+        ee_pos = state['ee_position']
 
         goal_pos[2] = z_traj[i]
 

--- a/src/pybullet_controllers/pybullet_controllers/os_controller.py
+++ b/src/pybullet_controllers/pybullet_controllers/os_controller.py
@@ -18,7 +18,7 @@ class OSControllerBase(object):
         self._error_thresh = config['error_thresh']
         self._start_err = config['start_err']
 
-        self._robot.set_ctrl_mode('tor')
+        self._robot.set_control_mode('torque')
 
         self._run_ctrl = False
 
@@ -75,7 +75,7 @@ class OSControllerBase(object):
                 # command robot using the computed joint torques
                 self._robot.exec_torque_cmd(tau)
 
-                self._robot.step_if_not_rtsim()
+                pb.stepSimulation(self._robot._uid)
                 self._sim_time += self._sim_timestep
                 self._mutex.release()
 

--- a/src/pybullet_controllers/pybullet_controllers/os_impedance_ctrl.py
+++ b/src/pybullet_controllers/pybullet_controllers/os_impedance_ctrl.py
@@ -22,14 +22,14 @@ class OSImpedanceController(OSControllerBase):
         task-space force, and then the corresponding joint torques.
         """
         state = self._robot.get_state()
-        curr_pos, curr_ori = state['ee_pos'], state['ee_ori']
+        curr_pos, curr_ori = state['ee_position'], state['ee_orientation']
 
         delta_pos = self._goal_pos - curr_pos.reshape([3, 1])
         delta_ori = quatdiff_in_euler(
             curr_ori, self._goal_ori).reshape([3, 1])
         # print goal_pos, curr_pos
 
-        curr_vel, curr_omg = state['ee_vel'], state['ee_omg']
+        curr_vel, curr_omg = state['ee_linear_velocity'], state['ee_angular_velocity']
         # print self._goal_pos, curr_pos
         # Desired task-space force using PD law
         F = np.vstack([self._P_pos.dot(delta_pos), self._P_ori.dot(delta_ori)]) - \
@@ -38,11 +38,11 @@ class OSImpedanceController(OSControllerBase):
 
         error = np.asarray([np.linalg.norm(delta_pos), np.linalg.norm(delta_ori)])
 
-        J = self._robot.get_jacobian(state['joint_pos'])
+        J = self._robot.get_jacobian(state['joint_positions'])
 
         # joint torques to be commanded
         return np.dot(J.T, F).flatten(), error
 
     def _initialise_goal(self):
         state = self._robot.get_state()
-        self.update_goal(state['ee_pos'], state['ee_ori'])
+        self.update_goal(state['ee_position'], state['ee_orientation'])

--- a/src/pybullet_interfaces/pybullet_interfaces/franka_zmq_simulation_interface.py
+++ b/src/pybullet_interfaces/pybullet_interfaces/franka_zmq_simulation_interface.py
@@ -126,15 +126,15 @@ class FrankaZMQSimulationInterface(object):
         :rtype: list of float
         """
         state_list = []
-        state_list.extend(list(state['joint_pos']))
-        state_list.extend(list(state['joint_vel']))
-        state_list.extend(list(state['joint_eff']))
-        state_list.extend(list(state['ee_pos']))
-        state_list.extend(quaternion.as_float_array(state['ee_ori']))
-        state_list.extend(list(state['ee_vel']))
-        state_list.extend(list(state['ee_omg']))
-        state_list.extend(list(state['tip_state']['force']))
-        state_list.extend(list(state['tip_state']['torque']))
+        state_list.extend(list(state['joint_positions']))
+        state_list.extend(list(state['joint_velocities']))
+        state_list.extend(list(state['joint_torques']))
+        state_list.extend(list(state['ee_position']))
+        state_list.extend(quaternion.as_float_array(state['ee_orientation']))
+        state_list.extend(list(state['ee_linear_velocity']))
+        state_list.extend(list(state['ee_angular_velocity']))
+        state_list.extend(list(state['ee_force']))
+        state_list.extend(list(state['ee_torque']))
         state_list.extend(state['jacobian'].flatten('F'))  # F for column-major
         state_list.extend(state['inertia'].flatten('F'))  # F for column-major
         return state_list

--- a/src/pybullet_interfaces/pybullet_interfaces/franka_zmq_simulation_interface.py
+++ b/src/pybullet_interfaces/pybullet_interfaces/franka_zmq_simulation_interface.py
@@ -126,10 +126,10 @@ class FrankaZMQSimulationInterface(object):
         :rtype: list of float
         """
         state_list = []
-        state_list.extend(list(state['position']))
-        state_list.extend(list(state['velocity']))
-        state_list.extend(list(state['effort']))
-        state_list.extend(list(state['ee_point']))
+        state_list.extend(list(state['joint_pos']))
+        state_list.extend(list(state['joint_vel']))
+        state_list.extend(list(state['joint_eff']))
+        state_list.extend(list(state['ee_pos']))
         state_list.extend(quaternion.as_float_array(state['ee_ori']))
         state_list.extend(list(state['ee_vel']))
         state_list.extend(list(state['ee_omg']))

--- a/src/pybullet_robots/pybullet_robots/__init__.py
+++ b/src/pybullet_robots/pybullet_robots/__init__.py
@@ -1,1 +1,2 @@
+from .bullet_robot_description import BulletRobotDescription
 from .bullet_robot import BulletRobot

--- a/src/pybullet_robots/pybullet_robots/bullet_robot.py
+++ b/src/pybullet_robots/pybullet_robots/bullet_robot.py
@@ -2,107 +2,153 @@ import pybullet as pb
 import numpy as np
 import quaternion
 
+from .bullet_robot_description import BulletRobotDescription
 
-class BulletRobot(object):
-    def __init__(self, description_path, uid, config=None, realtime_sim=False):
+
+class BulletRobot(BulletRobotDescription):
+    """
+    Bullet Robot extending from Bullet Robot Description (tested only with the Franka Panda).
+    This is a collection of methods that gather 'real-time' information about the robot state and take control over the
+    robot. In other words, these are the methods called (at each time step) in the simulation loop. Additionally, a few
+    high level methods for enabling, disabling, and emergency stopping to simulate a real robot (if desired) are
+    implemented.
+
+    Available methods (for usage, see documentation at function definition):
+        - set_enforce_joint_limits
+        - enable
+        - disable
+        - _emergency_stop
+        - check_robot_state
+        - get_state
+        - get_joint_positions
+        - get_joint_velocities
+        - get_joint_efforts
+        - get_jacobian
+        - get_inertia
+        - get_joint_state
+        - get_ft_sensor_wrench
+        - get_link_state
+        - get_ee_state
+        - set_control_mode
+        - reset_joint_positions
+        - set_joint_positions_cmd
+        - set_joint_velocities_cmd
+        - set_joint_torques_cmd
+        - _check_joint_command
+        - goto_default_joint_positions
+    """
+
+    def __init__(self, robot_urdf, enforce_joint_limits, uid, config=None):
         """
-        :param description_path: path to description file (urdf, .bullet, etc.)
-        :param config: optional config file for specifying robot information 
-        :param uid: optional server id of bullet 
+        Constructor of the Robot class.
 
-        :type description_path: str
-        :type config: dict
+        :param robot_urdf: robot description file (urdf, .bullet, etc.)
+        :param enforce_joint_limits: Enforce joint limits or not
+        :param uid: server id of PyBullet
+        :param config: optional config file for specifying robot information
+
+        :type robot_urdf: str
+        :type enforce_joint_limits: bool
         :type uid: int
+        :type config: dict
         """
-        self._uid = uid
+        BulletRobotDescription.__init__(self, robot_urdf=robot_urdf, uid=uid, config=config)
+        self._enforce_joint_limits = enforce_joint_limits
+        self.enabled = False
 
-        extension = description_path.split('.')[-1]
-        if extension == "urdf":
-            robot_id = pb.loadURDF(
-                description_path, useFixedBase=True, physicsClientId=self._uid)
-        elif extension == 'sdf':
-            robot_id = pb.loadSDF(
-                description_path, useFixedBase=True, physicsClientId=self._uid)
-        elif extension == 'bullet':
-            robot_id = pb.loadBullet(
-                description_path, useFixedBase=True, physicsClientId=self._uid)
-        else:
-            robot_id = pb.loadMJCF(
-                description_path, useFixedBase=True, physicsClientId=self._uid)
-
-        self._id = robot_id
-
-        pb.setGravity(0.0, 0.0, 0.0, physicsClientId=self._uid)
-        if realtime_sim:
-            pb.setRealTimeSimulation(1, physicsClientId=self._uid)
-            pb.setTimeStep(0.01, physicsClientId=self._uid)
-        self._rt_sim = realtime_sim
-
-        self._all_joints = np.array(
-            range(pb.getNumJoints(self._id, physicsClientId=self._uid)))
-
-        self._movable_joints = self.get_movable_joints()
-
-        self._nu = len(self._movable_joints)
-        self._nq = self._nu
-
-        joint_information = self.get_joint_info()
-
-        self._all_joint_names = [info['jointName'].decode(
-            "utf-8") for info in joint_information]
-
-        self._all_joint_dict = dict(
-            zip(self._all_joint_names, self._all_joints))
-
-        if config is not None and config['ee_link_name'] is not None:
-            self._ee_link_name = config['ee_link_name']
-            self._ee_link_idx = config['ee_link_idx']
-        else:
-            self._ee_link_idx, self._ee_link_name = self._use_last_defined_link()
-
-        self._joint_limits = self.get_joint_limits()
-
-        self._ft_joints = [self._all_joints[-1]]
-
-        # by default, set FT sensor at last fixed joint
-        self.set_ft_sensor_at(self._ft_joints[0])
-
-    def step_sim(self):
-        pb.stepSimulation(self._uid)
-
-    def step_if_not_rtsim(self):
-        if not self._rt_sim:
-            self.step_sim()
-
-    def set_ft_sensor_at(self, joint_id, enable=True):
-        if joint_id in self._ft_joints and not enable:
-            self._ft_joints.remove(joint_id)
-        elif joint_id not in self._ft_joints and enable:
-            self._ft_joints.append(joint_id)
-        print("FT sensor at joint", joint_id)
-        pb.enableJointForceTorqueSensor(self._id, joint_id, enable, self._uid)
-
-    def __del__(self):
-        pb.disconnect(self._uid)
-
-    def _use_last_defined_link(self):
-        joint_information = pb.getJointInfo(
-            self._id, self._all_joints[-1], physicsClientId=self._uid)
-        return joint_information[-1] + 1, joint_information[-5]
-
-    def state(self):
+    def set_enforce_joint_limits(self, enforce_joint_limits):
         """
-        :return: Current robot state, as a dictionary, containing 
-                joint positions, velocities, efforts, zero jacobian,
-                joint space inertia tensor, end-effector position, 
+        Set boolean to enforce joint position, velocity, and effort limits during simulation.
+
+        :param enforce_joint_limits: Enforce joint limits or not
+        :type enforce_joint_limits: bool
+        """
+        self._enforce_joint_limits = enforce_joint_limits
+
+    def enable(self):
+        """
+        Enable robot.
+
+        :return: Robot status (enabled/disabled)
+        :rtype: bool
+        """
+        if self.check_robot_state(self.get_state()):
+            print("Robot enabled")
+            self.enabled = True
+        else:
+            print("Couldn't enable robot")
+            self.enabled = False
+        return self.enabled
+
+    def disable(self):
+        """
+        Disable robot.
+
+        :return: Robot status (enabled/disabled)
+        :rtype: bool
+        """
+        if self.enabled:
+            print("Robot disabled")
+        self._emergency_stop("", verbose=False)
+        return self.enabled
+
+    def _emergency_stop(self, msg="no reason specified", verbose=True):
+        """
+        Emergency stop of robot, put zero velocity in all joints.
+
+        :param msg: Reason for emergency stop
+        :param verbose: optional parameter to specify if message should be printed
+        :type msg: str
+        :type verbose: bool
+        """
+        self.enabled = False
+        pb.setJointMotorControlArray(
+            self._id, self._movable_joints, controlMode=pb.VELOCITY_CONTROL,
+            targetVelocities=[0] * self._nb_movable_joints, physicsClientId=self._uid)
+        if verbose:
+            print("Emergency stop! ", msg)
+
+    def check_robot_state(self, state):
+        """
+        Check if the current robot state is within the joint limits.
+
+        :param state: State of the robot
+        :type: state: dict
+
+        :return ok: Boolean if robot state is okay
+        :rtype ok: bool
+        """
+        ok = False
+        if not all([lower_pos_lim <= joint_pos <= upper_pos_lim for lower_pos_lim, upper_pos_lim, joint_pos in
+                    zip(self._joint_position_limits['lower'], self._joint_position_limits['upper'],
+                        state['joint_pos'])]):
+            message = "Joint position limits"
+        elif any([abs(joint_vel) >= vel_limit for joint_vel, vel_limit in
+                  zip(state['joint_vel'], self._joint_velocity_limits)]):
+            message = "Joint velocity limits"
+        elif any([abs(joint_effort) >= effort_limit for joint_effort, effort_limit in
+                  zip(state['joint_eff'], self._joint_effort_limits)]):
+            message = "Joint effort limits"
+        else:
+            return True
+        if not ok and not self._enforce_joint_limits:
+            print("WARNING: ", message)
+        if not ok and self._enforce_joint_limits:
+            self._emergency_stop(message)
+
+    def get_state(self):
+        """
+        :return: Current robot state, as a dictionary, containing
+                joint positions, velocities, efforts, jacobian,
+                joint space inertia tensor, end-effector position,
                 end-effector orientation, end-effector velocity (linear and angular),
                 end-effector force, end-effector torque
-        :rtype: dict: {'position': np.ndarray,
-                       'velocity': np.ndarray,
-                       'effort': np.ndarray,
+        :rtype: dict: {'joint_pos': np.ndarray,
+                       'joint_vel': np.ndarray,
+                       'joint_eff': np.ndarray,
                        'jacobian': np.ndarray,
                        'inertia': np.ndarray,
-                       'ee_point': np.ndarray,
+                       'ee_pos': np.ndarray,
                        'ee_ori': np.ndarray,
                        'ee_vel': np.ndarray,
                        'ee_omg': np.ndarray,
@@ -112,20 +158,19 @@ class BulletRobot(object):
         """
 
         state = {}
-        state['position'] = self.angles()
-        state['velocity'] = self.joint_velocities()
-        state['effort'] = self.joint_efforts()
-        state['jacobian'] = self.jacobian(None)
-        state['inertia'] = self.inertia(None)
+        state['joint_pos'], state['joint_vel'], _, state['joint_eff'] = self.get_joint_state()
+        state['jacobian'] = self.get_jacobian(state['joint_pos'])
+        state['inertia'] = self.get_inertia(state['joint_pos'])
 
-        state['ee_point'], state['ee_ori'] = self.ee_pose()
-
-        state['ee_vel'], state['ee_omg'] = self.ee_velocity()
+        state['ee_pos'], state['ee_ori'], state['ee_vel'], state['ee_omg'] = self.get_ee_state()
 
         tip_state = {}
-        ft_joint_state = pb.getJointState(self._id, max(
-            self._ft_joints), physicsClientId=self._uid)
-        ft = np.asarray(ft_joint_state[2])
+        if hasattr(self, "_ft_joints"):
+            ft_joint_state = pb.getJointState(self._id, max(
+                self._ft_joints), physicsClientId=self._uid)
+            ft = np.asarray(ft_joint_state[2])
+        else:
+            ft = [0.0] * 6
 
         tip_state['force'] = ft[:3]
         tip_state['torque'] = ft[3:]
@@ -134,321 +179,88 @@ class BulletRobot(object):
 
         return state
 
-    def jacobian(self, joint_angles=None):
+    def get_joint_positions(self):
         """
-        :return: Jacobian matrix for provided joint configuration
-        :rtype: ndarray (shape: 6x7)
+        Get current joint positions of movable joints.
 
-        :param joint_angles: Optional parameter. If different than None, 
-                             then returned jacobian will be evaluated at    
-                             given joint_angles. Otherwise the returned 
-                             jacobian will be evaluated at current robot 
-                             joint angles.
-
-        :type joint_angles: [float] * len(self.get_movable_joints)    
+        :return: Current joint positions of movable joints.
+        :rtype: list of float
         """
+        return self.get_joint_state()[0].tolist()
 
-        if joint_angles is None:
-            joint_angles = self.angles()
+    def get_joint_velocities(self):
+        """
+        Get current joint velocities of movable joints.
 
-        linear_jacobian, angular_jacobian = pb.calculateJacobian(bodyUniqueId=self._id,
-                                                                 linkIndex=self._ee_link_idx,
-                                                                 localPosition=[
-                                                                     0.0, 0.0, 0.0],
-                                                                 objPositions=joint_angles.tolist(),
-                                                                 objVelocities=np.zeros(
-                                                                     self.n_joints()).tolist(),
-                                                                 objAccelerations=np.zeros(self.n_joints()).tolist(),
-                                                                 physicsClientId=self._uid)
+        :return: Current joint velocities of movable joints
+        :rtype: list of float
+        """
+        return self.get_joint_state()[1].tolist()
 
-        jacobian = np.vstack(
-            [np.array(linear_jacobian), np.array(angular_jacobian)])
+    def get_joint_efforts(self):
+        """
+        Get current joint efforts of movable joints.
 
+        :return: Current joint efforts of movable joints
+        :rtype: list of float
+        """
+        return self.get_joint_state()[3].tolist()
+
+    def get_jacobian(self, joint_positions):
+        """
+        Compute jacobian for given joint positions.
+
+        :param joint_positions: The returned jacobian will be evaluated at given joint positions
+        :type joint_positions: numpy.ndarray
+
+        :return: Jacobian matrix for current or provided joint configuration, of shape (6, DOF), or False if unsuccessful
+        :rtype: numpy.ndarray
+        """
+        if len(joint_positions) is not self._nb_movable_joints:
+            print("Invalid number of elements in your input.")
+            return False
+        else:
+            linear_jac, angular_jac = pb.calculateJacobian(bodyUniqueId=self._id,
+                                                           linkIndex=self._ee_link_idx,
+                                                           localPosition=[0.0, 0.0, 0.0],
+                                                           objPositions=joint_positions.tolist(),
+                                                           objVelocities=np.zeros(self._nb_movable_joints).tolist(),
+                                                           objAccelerations=np.zeros(self._nb_movable_joints).tolist(),
+                                                           physicsClientId=self._uid)
+
+        jacobian = np.vstack([np.array(linear_jac), np.array(angular_jac)])
         return jacobian
 
-    def ee_pose(self):
+    def get_inertia(self, joint_positions):
         """
+        Compute the inertia matrix for given joint positions.
 
-        :return: end-effector pose of this robot in the format (position,orientation)
-        .. note: orientation is a quaternion following Hamilton convention, i.e. (w, x, y, z)
+        :param joint_positions: The returned inertia is evaluated at given joint positions
+        :type joint_positions: numpy.ndarray
+
+        :return: Inertia matrix for current or provided joint configuration, of shape (DOF, DOF), or False if unsuccessful
+        :rtype: numpy.ndarray
         """
-        return self.get_link_pose(link_id=self._ee_link_idx)
-
-    def ee_velocity(self):
-        """
-
-        :return: end-effector velocity, which includes linear and angular velocities, i.e. (v,omega)
-        :rtype: np.ndarray
-        """
-
-        return self.get_link_velocity(link_id=self._ee_link_idx)
-
-    def get_link_state(self, link_idx, as_tuple=False):
-        """
-        returns orientation in bullet format quaternion [x,y,z,w]
-        """
-
-        link_state = pb.getLinkState(self._id, link_idx, computeLinkVelocity=1, physicsClientId=self._uid)
-
-        if not as_tuple:
-            ee_pos = np.asarray(link_state[0])
-            ee_ori = np.asarray(link_state[1])
-            ee_vel = np.asarray(link_state[2])
-            ee_omg = np.asarray(link_state[3])
+        if len(joint_positions) is not self._nb_movable_joints:
+            print("Invalid number of elements in your input.")
+            return False
         else:
-            ee_pos = link_state[0]
-            ee_ori = link_state[1]
-            ee_vel = link_state[2]
-            ee_omg = link_state[3]
-
-        return ee_pos, ee_ori, ee_vel, ee_omg
-
-    def get_ee_wrench(self, local=False, verbose=False):
-        '''
-        :param local: if True, computes reaction forces in local sensor frame, else in base frame of robot
-        :type local: bool
-        :return: End effector forces and torques. Returns [fx, fy, fz, tx, ty, tz]
-        :rtype: np.ndarray
-        '''
-
-        _, _, jnt_reaction_force, _ = self.get_joint_state(self._ft_joints[-1])
-
-        if not local:
-            jnt_reaction_force = np.asarray(jnt_reaction_force)
-            ee_pos, ee_ori = self.get_link_pose(self._ft_joints[-1])
-            rot_mat = quaternion.as_rotation_matrix(ee_ori)
-            f = np.dot(rot_mat, np.asarray([-jnt_reaction_force[0], -jnt_reaction_force[1], -jnt_reaction_force[2]]))
-            t = np.dot(rot_mat,
-                       np.asarray([-jnt_reaction_force[0 + 3], -jnt_reaction_force[1 + 3], -jnt_reaction_force[2 + 3]]))
-            jnt_reaction_force = np.append(f, t).flatten()
-
-        return jnt_reaction_force
-
-    def inertia(self, joint_angles=None):
-        """
-
-        :param joint_angles: optional parameter, if not None, then returned inertia is evaluated at given joint_angles.
-            Otherwise, returned inertia tensor is evaluated at current joint angles.
-        :return: Joint space inertia tensor
-        """
-
-        if joint_angles is None:
-            joint_angles = self.angles()
-
-        inertia_tensor = np.array(pb.calculateMassMatrix(
-            self._id, joint_angles.tolist()))
-
+            inertia_tensor = np.array(pb.calculateMassMatrix(self._id, joint_positions.tolist()))
         return inertia_tensor
-
-    def inverse_kinematics(self, position, orientation=None):
-        """
-
-        :param position: target position
-        :param orientation: target orientation in quaternion format (w, x, y , z)
-        :return: joint positions that take the end effector to the desired target position and/or orientation, and success status (solution_found) of IK operation.
-        """
-
-        solution = None
-        if orientation is None:
-
-            solution = pb.calculateInverseKinematics(self._id,
-                                                     self._ee_link_idx,
-                                                     targetPosition=position, physicsClientId=self._uid)
-        else:
-
-            orientation = [orientation[1], orientation[2],
-                           orientation[3], orientation[0]]
-            solution = pb.calculateInverseKinematics(self._id,
-                                                     self._ee_link_idx,
-                                                     targetPosition=position,
-                                                     targetOrientation=orientation, physicsClientId=self._uid)
-
-        return np.array(solution), solution is None
-
-    def q_mean(self):
-        """
-        :return: Mean joint positions.
-        :rtype: [float] * self._nq
-        """
-        return self._joint_limits['mean']
-
-    def joint_names(self):
-        """
-        :return: Joint names.
-        :rtype: [str] * self._nq
-        """
-        return self._all_joint_names
-
-    def joint_ids(self):
-        """
-        :return: Get joint ids (bullet id) for all robots.
-        :rtype: [int] * self._nq
-        """
-        return self._all_joints
-
-    def angles(self):
-        """
-        :return: Current joint positions.
-        :rtype: [float] * self._nq
-        """
-        return self.get_joint_state()[0]
-
-    def joint_velocities(self):
-        """
-        :return: Current velocities of all joints (movable, non-movable).
-        :rtype: [float] * self._nq
-        """
-        return self.get_joint_state()[1]
-
-    def joint_efforts(self):
-        """
-        :return: Current efforts of all joints (movable, non-movable).
-        :rtype: [float] * self._nq
-        """
-        return self.get_joint_state()[3]
-
-    def n_cmd(self):
-        """
-        :return: Number of motors (controls)
-        :rtype: float
-        """
-        return self._nu
-
-    def n_joints(self):
-        """
-        :return: Number of joints
-        :rtype: float
-        """
-        return self._nq
-
-    def set_joint_velocities(self, cmd, joints=None):
-        """
-        Set motor velocities. Use for velocity controlling.
-
-        :param cmd: joint velocity values
-        :type cmd: [float] * self._nu
-
-        """
-        if joints is None:
-            joints = self._movable_joints
-
-        pb.setJointMotorControlArray(
-            self._id, joints, controlMode=pb.VELOCITY_CONTROL, targetVelocities=cmd, physicsClientId=self._uid)
-
-    def set_joint_torques(self, cmd, joints=None):
-        """
-        Set motor torques. Use for velocity controlling.
-
-        :param cmd: joint torque values
-        :type cmd: [float] * self._nu
-
-        """
-
-        if joints is None:
-            joints = self._movable_joints
-
-        pb.setJointMotorControlArray(
-            self._id, joints, controlMode=pb.TORQUE_CONTROL, forces=cmd, physicsClientId=self._uid)
-
-    def set_joint_positions_delta(self, cmd, joints=None, forces=None):
-        """
-        Execute position command by specifying target joint velocities. (?!)
-
-        :param cmd: joint velocity values
-        :type cmd: [float] * self._nu
-
-        """
-        if joints is None:
-            joints = self._movable_joints
-
-        if forces is None:
-            forces = np.ones(len(joints)) * 1.5
-
-        pb.setJointMotorControlArray(self._id, joints,
-                                     controlMode=pb.POSITION_CONTROL,
-                                     targetVelocities=cmd,
-                                     forces=forces, physicsClientId=self._uid)
-
-    def set_joint_positions(self, cmd, joints=None, forces=None):
-        """
-        Set target joint positions. Use for position controlling.
-
-        :param cmd: joint position values
-        :type cmd: [float] * self._nu
-
-        """
-        vels = [0.0005 for n in range(len(cmd))]
-        pb.setJointMotorControlArray(self._id, joints, controlMode=pb.POSITION_CONTROL,
-                                     targetPositions=cmd, targetVelocities=vels, physicsClientId=self._uid)
-
-    def get_joint_info(self):
-        """
-        :return: JointInfo() method return values from pybullet            
-        :rtype: [dict] * self._nq
-        """
-        attribute_list = ['jointIndex', 'jointName', 'jointType',
-                          'qIndex', 'uIndex', 'flags',
-                          'jointDamping', 'jointFriction', 'jointLowerLimit',
-                          'jointUpperLimit', 'jointMaxForce', 'jointMaxVelocity', 'linkName',
-                          'jointAxis', 'parentFramePos', 'parentFrameOrn', 'parentIndex']
-
-        joint_information = []
-        for idx in self._all_joints:
-            info = pb.getJointInfo(self._id, idx, physicsClientId=self._uid)
-            joint_information.append(dict(zip(attribute_list, info)))
-
-        return joint_information
-
-    def get_link_pose(self, link_id=-3):
-        """
-        :return: Pose of link (Cartesian positionof center of mass, 
-                            Cartesian orientation of center of mass in quaternion [x,y,z,w]) 
-        :rtype: [np.ndarray, np.quaternion]
-
-        :param link_id: optional parameter to specify the link id. If not provided,
-                        will return pose of end-effector
-        :type link_id: int
-        """
-        if link_id == -3:
-            self._ee_link_idx
-
-        link_state = pb.getLinkState(
-            self._id, link_id, physicsClientId=self._uid)
-        pos = np.asarray(link_state[0])
-        ori = np.quaternion(link_state[1][3], link_state[1][0], link_state[1][1],
-                            link_state[1][2])  # hamilton convention
-
-        return pos, ori
-
-    def get_link_velocity(self, link_id=-3):
-        """
-        :return: Velocity of link (linear, angular in cartesian world frame) 
-        :rtype: [np.ndarray, np.ndarray]
-
-        :param link_id: optional parameter to specify the link id. If not provided,
-                        will return velocity of end-effector
-        :type link_id: int
-        """
-
-        if link_id == -3:
-            self._ee_link_idx
-
-        link_state = pb.getLinkState(
-            self._id, link_id, computeLinkVelocity=1, physicsClientId=self._uid)
-
-        lin_vel = np.asarray(link_state[6])
-        ang_vel = np.asarray(link_state[7])
-
-        return lin_vel, ang_vel
 
     def get_joint_state(self, joint_id=None):
         """
-        :return: joint positions, velocity, reaction forces, joint efforts as given from
-                bullet physics
-        :rtype: [np.ndarray, np.ndarray, np.ndarray, np.ndarray]
+        Get joint state(s) (position, velocty, force, effort).
+
+        :param joint_id: Optional parameter, if different from None, then only the joint state of the desired joint is
+                         returned (if it exists), otherwise the joint states of all joints are returned.
+        :type joint_id: int
+
+        :return: Joint positions, velocities, reaction forces, and efforts of all movable joints given by bullet physics
+        :rtype: list of numpy.ndarray
         """
         if joint_id is None:
-            joint_angles = []
+            joint_positions = []
             joint_velocities = []
             joint_reaction_forces = []
             joint_efforts = []
@@ -456,207 +268,306 @@ class BulletRobot(object):
             for idx in self._movable_joints:
                 joint_state = pb.getJointState(
                     self._id, idx, physicsClientId=self._uid)
-
-                joint_angles.append(joint_state[0])
-
+                joint_positions.append(joint_state[0])
                 joint_velocities.append(joint_state[1])
-
                 joint_reaction_forces.append(joint_state[2])
-
                 joint_efforts.append(joint_state[3])
-
-            return np.array(joint_angles), np.array(joint_velocities), np.array(joint_reaction_forces), np.array(
+            return np.array(joint_positions), np.array(joint_velocities), np.array(joint_reaction_forces), np.array(
                 joint_efforts)
 
         else:
-            jnt_state = pb.getJointState(
-                self._id, joint_id, physicsClientId=self._uid)
+            if joint_id in self._all_joints:
+                joint_state = pb.getJointState(
+                    self._id, joint_id, physicsClientId=self._uid)
+                joint_positions = joint_state[0]
+                joint_velocities = joint_state[1]
+                joint_reaction_forces = joint_state[2]
+                joint_efforts = joint_state[3]
+                return joint_positions, joint_velocities, np.array(joint_reaction_forces), joint_efforts
+            else:
+                print("Desired joint index doesn't exist")
+                return None
 
-            jnt_poss = jnt_state[0]
+    def get_ft_sensor_wrench(self, ft_joint_index, in_world_frame=True, ft_link='child'):
+        '''
+        Get wrench of force torque sensor in world or local frame.
 
-            jnt_vels = jnt_state[1]
+        :param in_world_frame: if True, computes reaction forces in local sensor frame, else in base frame of robot
+        :param ft_link: One of ['child', 'parent']. Decide if child or parent link should be considered to transform
+                        wrench into world frame.
+        :type in_world_frame: bool
+        :type ft_link: str
 
-            jnt_reaction_forces = jnt_state[2]
+        :return: End effector forces and torques [fx, fy, fz, tx, ty, tz]
+        :rtype: np.ndarray
+        '''
+        if not hasattr(self, "_ft_joints"):
+            print("There are no joints with FT sensors defined.")
+            return False
+        if hasattr(self, "_ft_joints") and not ft_joint_index in self._ft_joints:
+            print("No FT sensor at specified joint")
+            return False
+        if in_world_frame and ft_link not in ['child', 'parent']:
+            print("Parameter ft_link has to be one of ['child', 'parent'].")
+            return False
 
-            jnt_applied_torques = jnt_state[3]
+        _, _, joint_reaction_force, _ = self.get_joint_state(ft_joint_index)
 
-            return jnt_poss, jnt_vels, np.array(jnt_reaction_forces), jnt_applied_torques
+        if in_world_frame:
+            joint_reaction_force = np.asarray(joint_reaction_force)
+            if ft_link == 'child':
+                link_pos, link_ori, _, _ = self.get_link_state(ft_joint_index)
+            else:
+                link_pos, link_ori, _, _ = self.get_link_state(ft_joint_index - 1)
+            rot_mat = quaternion.as_rotation_matrix(link_ori)
+            f = np.dot(rot_mat,
+                       np.asarray([-joint_reaction_force[0], -joint_reaction_force[1], -joint_reaction_force[2]]))
+            t = np.dot(rot_mat,
+                       np.asarray([-joint_reaction_force[3], -joint_reaction_force[4], -joint_reaction_force[5]]))
+            joint_reaction_force = np.append(f, t).flatten()
 
-    def set_joint_angles(self, joint_angles, joint_indices=None):
+        return joint_reaction_force
+
+    def get_link_state(self, link_id):
         """
-        Set joint positions. Note: will hard reset the joints, no controllers used.
+        Get state of desired link.
 
-        :param cmd: joint position values
-        :type cmd: [float] * self._nu
+        :param link_id: Index of desired link
+        :type link_id: int
+
+        :return: State of link (cartesian position of link frame in robot description,
+                                cartesian orientation of link frame in robot description in quaternion wxyz,
+                                cartesian linear velocity, cartesian angular velocity)
+        :rtype: list of numpy.ndarray
+        """
+        if link_id not in self._all_links:
+            print("Link doesn't exists.")
+            return False
+        else:
+            link_state = pb.getLinkState(self._id, link_id, computeLinkVelocity=1, physicsClientId=self._uid)
+            pos = np.asarray(link_state[4])
+            ori = np.quaternion(link_state[5][3], link_state[5][0], link_state[5][1],
+                                link_state[5][2])  # hamilton convention
+            lin_vel = np.asarray(link_state[6])
+            ang_vel = np.asarray(link_state[7])
+
+            return pos, ori, lin_vel, ang_vel
+
+    def get_ee_state(self):
+        """
+        Get end-effector state.
+
+        :return: End-effector link state of this robot in the format (position, orientation, linear velocity, angular
+                 velocity). Note: Orientation is a quaternion following Hamilton convention, i.e. (w, x, y, z)
+        :rtype: list of numpy.ndarray
+        """
+        return self.get_link_state(link_id=self._ee_link_idx)
+
+    def set_control_mode(self, control_mode='position'):
+        """
+        Use to set the robot control mode.
+
+        :param control_mode: Desired control mode, one of ['position','velocity','torque']
+        :type control_mode: str
+
+        :return: Success of action
+        :rtype: bool
 
         """
+        # TODO
+        if self.enabled:
+            print("Disable robot first to change control mode")
+            return False
 
-        if joint_indices is None:
+        if self._enforce_joint_limits:
+            efforts = self._joint_effort_limits
+        else:
+            efforts = [500] * self._nb_movable_joints
+
+        if control_mode == 'position':
+            pb.setJointMotorControlArray(self._id, self._movable_joints, pb.POSITION_CONTROL,
+                                         targetPositions=self.get_joint_positions(), forces=efforts,
+                                         physicsClientId=self._uid)
+        elif control_mode == 'velocity':
+            pb.setJointMotorControlArray(self._id, self._movable_joints, pb.VELOCITY_CONTROL,
+                                         targetVelocities=[0.0] * self._nb_movable_joints, forces=efforts,
+                                         physicsClientId=self._uid)
+        elif control_mode == 'torque':
+            pb.setJointMotorControlArray(self._id, self._movable_joints, pb.VELOCITY_CONTROL,
+                                         forces=[0.0] * self._nb_movable_joints, physicsClientId=self._uid)
+        else:
+            print("Invalid control mode, choose one of ['position', 'velocity', 'torque'].")
+            return False
+        return True
+
+    def reset_joint_positions(self, joint_positions, joint_indices=None):
+        """
+        Reset joint positions of movable joints. Note: this will hard reset the joints, no controllers used.
+
+        :param joint_positions: Joint position values
+        :param joint_indices: Optional parameter, if different from None, then only the joint position of the specified
+                              joints are changed. Otherwise all movable joints are considered.
+        :type joint_positions: list of float
+        :type joint_indices: list of int
+
+        :return: Boolean if the action was successful.
+        :rtype: bool
+        """
+        if self.enabled:
+            print("Disable robot first to reset joint positions")
+            return False
+
+        if joint_indices is not None:
+            if any([joint_id not in self._movable_joints for joint_id in joint_indices]):
+                print("You specified at least one joint that doesn't exist or is not movable.")
+                return False
+        else:
             joint_indices = self._movable_joints
 
-        for i, jnt_idx in enumerate(joint_indices):
-            pb.resetJointState(self._id, jnt_idx,
-                               joint_angles[i], physicsClientId=self._uid)
+        if len(joint_positions) is not len(joint_indices):
+            print("Your input variables must have the same length")
+            return False
+        if not all([lower_pos_lim <= joint_pos <= upper_pos_lim for lower_pos_lim, upper_pos_lim, joint_pos in
+                    zip(self._joint_position_limits['lower'][joint_indices],
+                        self._joint_position_limits['upper'][joint_indices],
+                        joint_positions)]) and self._enforce_joint_limits:
+            print("At least one of the desired values is outside joint limits")
+            return False
 
-    def get_movable_joints(self):
+        for i, joint_idx in enumerate(joint_indices):
+            pb.resetJointState(self._id, joint_idx,
+                               joint_positions[i], physicsClientId=self._uid)
+        return True
+
+    def set_joint_positions_cmd(self, joint_positions, joint_indices=None, kp=0.002, kd=1.0):
         """
-        :return: Ids of all movable joints.
-        :rtype: np.ndarray (shape: (self._nu,))
+        Set target joint positions for position control. This control method tries to minimize the error e =
+        position_gain*(desired_position-actual_position)+velocity_gain*(desired_velocity-actual_velocity).
 
+        :param joint_positions: desired joint positions
+        :param joint_indices: Optional parameter, if different from None, then only the joint position of the specified
+                              joints are changed. Otherwise all movable joints are considered.
+        :param kp: position gain in error computation
+        :param kd: velocity gain in error computation
+
+        :type joint_positions: list of float
+        :type joint_indices: list of int
+        :type kp: float
+        :type kd: float
+
+        :return: Boolean if the operation was successful.
+        :rtype: bool
         """
-        movable_joints = []
-        for i in self._all_joints:
-            joint_info = pb.getJointInfo(
-                self._id, i, physicsClientId=self._uid)
-            q_index = joint_info[3]
-            if q_index > -1:
-                movable_joints.append(i)
+        joint_indices = self._check_joint_command(joint_positions, joint_indices)
+        if not joint_indices:
+            return False
 
-        return np.array(movable_joints)
+        if not all([lower_pos_lim <= joint_pos <= upper_pos_lim for lower_pos_lim, upper_pos_lim, joint_pos in
+                    zip(self._joint_position_limits['lower'][joint_indices],
+                        self._joint_position_limits['upper'][joint_indices],
+                        joint_positions)]) and self._enforce_joint_limits:
+            print("At least one of the desired values is outside joint limits")
+            return False
 
-    def get_all_joints(self):
+        vels = [0.005] * self._nb_movable_joints
+        efforts = [500] * self._nb_movable_joints
+        kp = [kp] * self._nb_movable_joints
+        kd = [kd] * self._nb_movable_joints
+        pb.setJointMotorControlArray(self._id, joint_indices, controlMode=pb.POSITION_CONTROL,
+                                     targetPositions=joint_positions, targetVelocities=vels, positionGains=kp,
+                                     velocityGains=kd, forces=efforts, physicsClientId=self._uid)
+        return True
+
+    def set_joint_velocities_cmd(self, joint_velocities, joint_indices=None):
         """
-        :return: Ids of all joints.
-        :rtype: np.ndarray (shape: (self._nq,))
+        Set joint velocities of movable joints.
 
+        :param joint_velocities: Joint velocity values
+        :param joint_indices: Optional parameter, if different from None, then only the joint velocities of the specified
+                              joints are changed. Otherwise all movable joints are considered.
+        :type joint_velocities: list of float
+        :type joint_indices: list of int
+
+        :return: Boolean if the operation was successful.
+        :rtype: bool
         """
-        return self._all_joints
+        joint_indices = self._check_joint_command(joint_velocities, joint_indices)
+        if not joint_indices:
+            return False
 
-    def get_joint_dict(self):
-        return self._all_joint_dict
+        if any(abs(joint_vel) > vel_limit for joint_vel, vel_limit in
+               zip(joint_velocities, [self._joint_velocity_limits[joint_id] for joint_id in
+                                      joint_indices])) and self._enforce_joint_limits:
+            self._emergency_stop("Desired velocities higher than max velocity")
+            return False
 
-    def get_joint_limits(self):
-        """
-        :return: Joint limits, mean positions, range
-        :rtype: dict {'lower': [float], 'upper': [float], 'mean': [float], 'range':[float]}
-        """
-
-        lower_lim = np.zeros(self.n_joints())
-
-        upper_lim = np.zeros(self.n_joints())
-
-        mean_ = np.zeros(self.n_joints())
-
-        range_ = np.zeros(self.n_joints())
-
-        for k, idx in enumerate(self._movable_joints):
-            lower_lim[k] = pb.getJointInfo(
-                self._id, idx, physicsClientId=self._uid)[8]
-
-            upper_lim[k] = pb.getJointInfo(
-                self._id, idx, physicsClientId=self._uid)[9]
-
-            mean_[k] = 0.5 * (lower_lim[k] + upper_lim[k])
-
-            range_[k] = (upper_lim[k] - lower_lim[k])
-
-        return {'lower': lower_lim, 'upper': upper_lim, 'mean': mean_, 'range': range_}
-
-    def get_joint_by_name(self, joint_name):
-        """
-        :return: Joint ID of given joint
-        :rtype: int
-
-        :param joint_name: name of joint
-        :type joint_name: str
-        """
-        if joint_name in self._all_joint_dict:
-            return self._all_joint_dict[joint_name]
+        if self._enforce_joint_limits:
+            efforts = self._joint_effort_limits
         else:
-            raise Exception("Joint name does not exist!")
+            efforts = [500] * self._nb_movable_joints
+        pb.setJointMotorControlArray(
+            self._id, self._movable_joints, controlMode=pb.VELOCITY_CONTROL, targetVelocities=joint_velocities,
+            forces=efforts, physicsClientId=self._uid)
+        return True
 
-    def configure_default_pos(self, pos, ori):
-        self._default_pos = pos
-        self._default_ori = ori
-        self.set_default_pos_ori()
-
-    def set_default_pos_ori(self):
-        self.set_pos_ori(self._default_pos, self._default_ori)
-
-    def set_pos_ori(self, pos, ori):
+    def set_joint_torques_cmd(self, joint_torques, joint_indices=None):
         """
-        Set robot position (base of robot)
+        Set joint torques of movable joints.
 
-        :param pos: position of CoM of base
-        :param ori: orientation of CoM of base (quaternion [x,y,z,w])
+        :param joint_torques: Joint torque values
+        :param joint_indices: Optional parameter, if different from None, then only the joint torques of the specified
+                              joints are changed. Otherwise all movable joints are considered.
+        :type joint_torques: list of float
+        :type joint_indices: list of int
 
+        :return: Boolean if the operation was successful.
+        :rtype: bool
         """
-        pb.resetBasePositionAndOrientation(
-            self._id, pos, ori, physicsClientId=self._uid)
+        joint_indices = self._check_joint_command(joint_torques, joint_indices)
+        if not joint_indices:
+            return False
 
-    def set_ctrl_mode(self, ctrl_type='pos'):
+        pb.setJointMotorControlArray(
+            self._id, joint_indices, controlMode=pb.TORQUE_CONTROL, forces=joint_torques, physicsClientId=self._uid)
+        return True
+
+    def _check_joint_command(self, joint_command, joint_indices=None):
         """
-        Use to disable the default position_control mode.
+        Check if joint command has correct lenght and joint indices.
 
-        :param ctrl_type: type of controller to use (give any string except 'pos' to enable
-                            velocity and torque control)
-        :type ctrl_type: str
+        :param joint_command: Desired joint command
+        :param joint_indices: Optional parameter specifing the commanded joints
+        :type joint_command: list of float
+        :type joint_indices: list of int
 
+        :return: Boolean if joint command is valid
+        :rtype: bool
         """
+        if not self.enabled:
+            print("Enable robot first.")
+            return False
 
-        angles = self.angles()
-
-        for k, jnt_index in enumerate(self._movable_joints):
-            pb.resetJointState(self._id, jnt_index,
-                               angles[k], physicsClientId=self._uid)
-
-        if ctrl_type == 'pos':
-
-            pb.setJointMotorControlArray(self._id, self._movable_joints, pb.POSITION_CONTROL,
-                                         targetPosition=angles, forces=[500] * len(self._movable_joints),
-                                         physicsClientId=self._uid)
-
+        if joint_indices is not None:
+            if any([joint_id not in self._movable_joints for joint_id in joint_indices]):
+                print("You specified at least one joint that doesn't exist or is not movable.")
+                return False
         else:
-            pb.setJointMotorControlArray(self._id, self._movable_joints, pb.VELOCITY_CONTROL,
-                                         forces=[0.0] * len(self._movable_joints), physicsClientId=self._uid)
+            joint_indices = self._movable_joints
 
-    def triangle_mesh(self):
+        if len(joint_command) is not len(joint_indices):
+            print("Your input variables must have the same length")
+            return False
+        return joint_indices
 
-        visual_shape_data = pb.getVisualShapeData(
-            self._id, physicsClientId=self._uid)
-
-        triangle_mesh = [None] * len(visual_shape_data)
-
-        for i, data in enumerate(visual_shape_data):
-            link_index = data[1]
-            geometry_type = data[2]
-            dimensions = data[3]
-            mesh_asset_file = data[4]
-            local_pos = data[5]
-            local_ori = data[6]
-            colour = data[7]
-
-            link_state = pb.getLinkState(
-                self._id, link_index, physicsClientId=self._uid)
-            pos = link_state[0]
-            ori = link_state[1]
-            loc_inertial_pos = link_state[2]
-            loc_inertial_ori = link_state[3]
-
-            inv_loc_inertial_pos, inv_loc_inertial_ori = pb.invertTransform(loc_inertial_pos,
-                                                                            loc_inertial_ori, physicsClientId=self._uid)
-            tp, to = pb.multiplyTransforms(inv_loc_inertial_pos,
-                                           inv_loc_inertial_ori,
-                                           pos, ori, physicsClientId=self._uid)
-
-            global_pos, global_ori = pb.multiplyTransforms(
-                tp, to, local_pos, local_ori, physicsClientId=self._uid)
-
-            triangle_mesh[i] = (np.asarray(global_pos),)
-
-        return triangle_mesh
-
-    @staticmethod
-    def add_to_models_path(path):
+    def goto_default_joint_positions(self):
         """
-        Add the specified directory (absolute) to Pybullet's searchpath for easily adding models from the path.
+        Reset joint positions of movable joints to the default joint positions.
 
-        :param path: the absolute path to the directory
-        :type path: str
+        :return: Boolean if action was successful
+        :rtype: bool
         """
-        import os
-        if os.path.isdir(path):
-            pb.setAdditionalSearchPath(path)
-            print("Info: Added {} to Pybullet path.".format(path))
+        if hasattr(self, "_default_joint_positions"):
+            return self.reset_joint_positions(self._default_joint_positions)
         else:
-            print("Error adding to Pybullet path! {} not a directory.".format(path))
+            print("Default joint positions not set yet.")
+            return False

--- a/src/pybullet_robots/pybullet_robots/bullet_robot.py
+++ b/src/pybullet_robots/pybullet_robots/bullet_robot.py
@@ -17,7 +17,6 @@ class BulletRobot(BulletRobotDescription):
         - set_enforce_joint_limits
         - enable
         - disable
-        - _emergency_stop
         - check_robot_state
         - get_state
         - get_joint_positions
@@ -34,7 +33,6 @@ class BulletRobot(BulletRobotDescription):
         - set_joint_positions_cmd
         - set_joint_velocities_cmd
         - set_joint_torques_cmd
-        - _check_joint_command
         - goto_default_joint_positions
     """
 

--- a/src/pybullet_robots/pybullet_robots/bullet_robot_description.py
+++ b/src/pybullet_robots/pybullet_robots/bullet_robot_description.py
@@ -13,17 +13,13 @@ class BulletRobotDescription(object):
         - get_all_joints
         - get_joint_names
         - get_link_names
-        - _find_joint_info
         - get_joint_dict
         - get_joint_index_by_name
         - get_link_dict
         - get_link_index_by_name
-        - _find_movable_joints
         - get_movable_joints
         - get_nb_movable_joints
         - get_ft_sensor_joints
-        - _use_last_defined_link
-        - _find_joint_position_limits
         - get_joint_position_limits
         - get_joint_velocity_limits
         - get_joint_effort_limits
@@ -31,7 +27,6 @@ class BulletRobotDescription(object):
         - set_ft_sensor_at
         - set_default_joint_positions
         - get_default_joint_positions
-        - _set_base_pose
         - get_base_pos_ori
     """
 

--- a/src/pybullet_robots/pybullet_robots/bullet_robot_description.py
+++ b/src/pybullet_robots/pybullet_robots/bullet_robot_description.py
@@ -1,0 +1,398 @@
+import pybullet as pb
+import numpy as np
+
+
+class BulletRobotDescription(object):
+    """
+    Bullet Robot Description for a robotic manipulator (tested only with the Franka Panda).
+    This is a collection of methods that gather and store static information from the robot descritption urdf
+    such that this information only has to be requested from the pybullet physics engine once.
+
+    Available methods (for usage, see documentation at function definition):
+        - get_nb_joints
+        - get_all_joints
+        - get_joint_names
+        - get_link_names
+        - _find_joint_info
+        - get_joint_dict
+        - get_joint_index_by_name
+        - get_link_dict
+        - get_link_index_by_name
+        - _find_movable_joints
+        - get_movable_joints
+        - get_nb_movable_joints
+        - get_ft_sensor_joints
+        - _use_last_defined_link
+        - _find_joint_position_limits
+        - get_joint_position_limits
+        - get_joint_velocity_limits
+        - get_joint_effort_limits
+        - get_joint_limits
+        - set_ft_sensor_at
+        - set_default_joint_positions
+        - get_default_joint_positions
+        - _set_base_pose
+        - get_base_pos_ori
+    """
+
+    def __init__(self, robot_urdf, uid, config=None):
+        """
+        Constructor of the Robot Description class. Gathers all information from the robot urdf description
+        regarding joints and links and implements simple getter functions of robot information.
+
+        :param robot_urdf: robot description file (urdf, .bullet, etc.)
+        :param uid: server id of PyBullet
+        :param config: optional config file for specifying robot information
+
+        :type robot_urdf: str
+        :type uid: int
+        :type config: dict
+        """
+        self._uid = uid
+
+        extension = robot_urdf.split('.')[-1]
+        if extension == "urdf":
+            robot_id = pb.loadURDF(robot_urdf, useFixedBase=True, physicsClientId=self._uid)
+        elif extension == 'sdf':
+            robot_id = pb.loadSDF(robot_urdf, useFixedBase=True, physicsClientId=self._uid)
+        elif extension == 'bullet':
+            robot_id = pb.loadBullet(robot_urdf, useFixedBase=True, physicsClientId=self._uid)
+        else:
+            robot_id = pb.loadMJCF(robot_urdf, useFixedBase=True, physicsClientId=self._uid)
+
+        self._id = robot_id
+
+        self._nb_joints = pb.getNumJoints(self._id, physicsClientId=self._uid)
+        self._all_joints = range(self._nb_joints)
+        self._all_joint_info = self._get_joint_info()
+        self._all_joint_names = [joint['jointName'].decode("utf-8") for joint in self._all_joint_info]
+        self._all_joint_dict = dict(zip(self._all_joint_names, self._all_joints))
+
+        self._all_links = self._all_joints
+        self._all_link_names = [joint['linkName'].decode("utf-8") for joint in self._all_joint_info]
+        self._all_link_dict = dict(zip(self._all_link_names, self._all_links))
+
+        self._movable_joints = self._find_movable_joints()
+        self._nb_movable_joints = len(self._movable_joints)
+
+        if config is not None:
+            if config['ee_link_name'] is not None and config['ee_link_idx'] is not None:
+                self._ee_link_name = config['ee_link_name']
+                self._ee_link_idx = config['ee_link_idx']
+        else:
+            self._ee_link_idx, self._ee_link_name = self._use_last_defined_link()
+
+        self._joint_position_limits = self._find_joint_position_limits()
+        self._joint_velocity_limits = [pb.getJointInfo(self._id, joint, physicsClientId=self._uid)[11] for joint in
+                                       self._movable_joints]
+        self._joint_effort_limits = [pb.getJointInfo(self._id, joint, physicsClientId=self._uid)[10] for joint in
+                                     self._movable_joints]
+
+        self._joint_limits = [{'pos_lower': x[0], 'pos_upper': x[1], 'velocity': x[2], 'effort': x[3]}
+                              for x in zip(self._joint_position_limits['lower'],
+                                           self._joint_position_limits['upper'],
+                                           self._joint_velocity_limits, self._joint_effort_limits)]
+
+        # # by default, set FT sensor at last fixed joint
+        # self._ft_joints = [self._all_joints[-1]]
+        # self.set_ft_sensor_at(self._ft_joints[0])
+
+        self._base_pose = {}
+        if config is not None:
+            if config['base_position'] is not None and config['base_orientation'] is not None:
+                self._base_pose['position'] = config['base_position']
+                self._base_pose['orientation'] = config['base_orientation']
+        else:
+            self._base_pose = {'position': [0, 0, 0], 'orientation': [0, 0, 0, 1]}
+        self._set_base_pose()
+
+    def get_nb_joints(self):
+        """
+        Get number of all joints in the robot description.
+
+        :return: Number of joints in the robot description
+        :rtype: int
+        """
+        return self._nb_joints
+
+    def get_all_joints(self):
+        """
+        Get indices of all joints in the robot description.
+
+        :return: Indices of all joints in the robot description
+        :rtype: list of int
+        """
+        return self._all_joints
+
+    def get_joint_names(self):
+        """
+        Get list with the names of all joints in the robot description.
+
+        :return: List of all joint names in the robot description
+        :rtype: list of str
+        """
+        return self._all_joint_names
+
+    def get_link_names(self):
+        """
+        Get list with the names of all link in the robot description.
+
+        :return: List of all link names in the robot description
+        :rtype: list of str
+        """
+        return self._all_link_names
+
+    def _get_joint_info(self):
+        """
+        Get a dicts with all the information obtained from pybullets getJointInfo method for all joints.
+
+        :return: getJointInfo() method return values from pybullet for all joints
+        :rtype: list of dict
+        """
+        attribute_list = ['jointIndex', 'jointName', 'jointType',
+                          'qIndex', 'uIndex', 'flags',
+                          'jointDamping', 'jointFriction', 'jointLowerLimit',
+                          'jointUpperLimit', 'jointMaxForce', 'jointMaxVelocity', 'linkName',
+                          'jointAxis', 'parentFramePos', 'parentFrameOrn', 'parentIndex']
+
+        joint_information = []
+        for idx in self._all_joints:
+            info = pb.getJointInfo(self._id, idx, physicsClientId=self._uid)
+            joint_information.append(dict(zip(attribute_list, info)))
+        return joint_information
+
+    def get_joint_dict(self):
+        """
+        Get a dict with all joint names mapping to their joint index in the robot description.
+
+        :return: Dict with all joint names and corresponding index
+        :rtype: dict[str, int]
+        """
+        return self._all_joint_dict
+
+    def get_joint_index_by_name(self, joint_name):
+        """
+        Get a joint index by the joint's name.
+        :param joint_name: Name of joint
+        :type joint_name: str
+
+        :return: Joint index of given joint in robot description.
+        :rtype: int
+        """
+        if joint_name in self._all_joint_dict:
+            return self._all_joint_dict[joint_name]
+        else:
+            raise Exception("Joint name does not exist!")
+
+    def get_link_dict(self):
+        """
+        Get a dict with all link names mapping to their link index in the robot description.
+
+        :return: Dict with all link names and corresponding index
+        :rtype: dict[str, int]
+        """
+        return self._all_link_dict
+
+    def get_link_index_by_name(self, link_name):
+        """
+        Get a link index by the link's name.
+        :param link_name: Name of link
+        :type link_name: str
+
+        :return: Link index of given link in robot description.
+        :rtype: int
+        """
+        if link_name in self._all_link_dict:
+            return self._all_link_dict[link_name]
+        else:
+            raise Exception("Link name does not exist!")
+
+    def _find_movable_joints(self):
+        """
+        Get joint indices of all movable joints.
+
+        :return: Indices of all movable joints in the robot description.
+        :rtype: list of int
+        """
+        movable_joints = []
+        for i in self._all_joints:
+            joint_info = pb.getJointInfo(
+                self._id, i, physicsClientId=self._uid)
+            # all moveable joints have type bigger than 0, -1 is a fixed joint
+            if joint_info[3] > -1:
+                movable_joints.append(i)
+        return movable_joints
+
+    def get_movable_joints(self):
+        """
+        Get joint indices of all movable joints in the robot description.
+        :return: Indices of all movable joints in the robot description.
+        :rtype: list of int
+        """
+        return self._movable_joints
+
+    def get_nb_movable_joints(self):
+        """
+        Get number of movable joints in the robot description.
+
+        :return: Number of movable joints in the robot description.
+        :rtype: int
+        """
+        return self._nb_movable_joints
+
+    def get_ft_sensor_joints(self):
+        """
+        Get indices of all joints with a force torque sensor activated.
+
+        :return: Joint indices of joints with force torque sensors in the robot description. Returns False if
+                 no joints have a FT sensor activated.
+        :rtype: list of int
+        """
+        if hasattr(self, "_ft_joints"):
+            return self._ft_joints
+        else:
+            print("No joints with FT sensor defined.")
+            return False
+
+    def _use_last_defined_link(self):
+        """
+        Get index and name of last link in the robot description.
+
+        :return: Index and name of last link of the robot.
+        :rtype: link_idx: int, link_name: str
+        """
+        joint_information = pb.getJointInfo(
+            self._id, self._all_joints[-1], physicsClientId=self._uid)
+        # joint_information[-1] is index of parent link, therefore add 1 to obtain child link index
+        return joint_information[-1] + 1, joint_information[-5].decode("utf-8")
+
+    def _find_joint_position_limits(self):
+        """
+        Find joint position limits, mean positions, and range for all movable joints.
+
+        :return: Joint position limits, mean positions, and range for all movable joints.
+        :rtype: dict[str, list of float]
+        """
+        lower_lim = np.zeros(self._nb_movable_joints)
+        upper_lim = np.zeros(self._nb_movable_joints)
+        mean_ = np.zeros(self._nb_movable_joints)
+        range_ = np.zeros(self._nb_movable_joints)
+
+        for k, idx in enumerate(self._movable_joints):
+            lower_lim[k] = pb.getJointInfo(
+                self._id, idx, physicsClientId=self._uid)[8]
+            upper_lim[k] = pb.getJointInfo(
+                self._id, idx, physicsClientId=self._uid)[9]
+            mean_[k] = 0.5 * (lower_lim[k] + upper_lim[k])
+            range_[k] = (upper_lim[k] - lower_lim[k])
+        return {'lower': lower_lim, 'upper': upper_lim, 'mean': mean_, 'range': range_}
+
+    def get_joint_position_limits(self):
+        """
+        Get joint positions limits, mean positions, and range for all movable joints.
+
+        :return: Joint position limits, mean positions, and range for all movable joints.
+        :rtype: dict[str, list of float]
+        """
+        return self._joint_position_limits
+
+    def get_joint_velocity_limits(self):
+        """
+        Get joint velocity limits for all movable joints.
+
+        :return: Joint velocity limits for all movable joints.
+        :rtype: list of float
+        """
+        return self._joint_velocity_limits
+
+    def get_joint_effort_limits(self):
+        """
+        Get joint effort limits for all movable joints.
+
+        :return: Joint effort limits for all movable joints.
+        :rtype: list of float
+        """
+        return self._joint_effort_limits
+
+    def get_joint_limits(self):
+        """
+        Get joint position, velocity, and effort limits for all movable joints.
+
+        :return: Joint position, velocity and effort limits for all movable joints.
+        :rtype: list of dict
+        """
+        return self._joint_limits
+
+    def set_ft_sensor_at(self, joint_id, enable=True):
+        """
+        Enable/Disable force/torque sensor at a desired joint
+        :param joint_id: Desired joint index
+        :param enable: Enable or disable FT sensor
+        :type joint_id: int
+        :type enable: bool | True
+
+        :return: Boolean if action was successful or not
+        :rtype: bool
+        """
+        if joint_id not in self._all_joints:
+            print("The desired joint doesn't exist in the robot description.")
+            return False
+        if joint_id in self._ft_joints and enable:
+            pass
+        elif joint_id in self._ft_joints and not enable:
+            self._ft_joints.remove(joint_id)
+        elif joint_id not in self._ft_joints and enable:
+            self._ft_joints.append(joint_id)
+        elif joint_id not in self._ft_joints and not enable:
+            print("There is no FT at the desired joint that could be disabled.")
+            return False
+        print("FT sensor at joint", joint_id)
+        pb.enableJointForceTorqueSensor(self._id, joint_id, enable, self._uid)
+        return True
+
+    def set_default_joint_positions(self, joint_positions):
+        """
+        Set default joint positions for all movable joints.
+
+        :param joint_positions: default joint positions of movable joints
+        :type joint_positions: list of float
+
+        :return: Boolean if action was successful
+        :rtype: bool
+        """
+        if len(joint_positions) is not self._nb_movable_joints:
+            print("Could not set default joint positions. Number of elements incorrect.")
+            return False
+        else:
+            self._default_joint_positions = joint_positions
+            return True
+
+    def get_default_joint_positions(self):
+        """
+        Get default joint positions of all movable joints.
+
+        :param joint_positions: default joint positions of movable joints
+        :type joint_positions: list of float
+
+        :return: Default joint positions or False if they have not been set yet
+        :rtype: list of float
+        """
+        if not hasattr(self, "_default_joint_positions"):
+            print("Default joint positions have not been set yet.")
+            return False
+        else:
+            return self._default_joint_positions
+
+    def _set_base_pose(self):
+        """
+        Set position and orientation of the CoM of the robot base.
+        """
+        pb.resetBasePositionAndOrientation(
+            self._id, self._base_pose['position'], self._base_pose['orientation'], physicsClientId=self._uid)
+
+    def get_base_pos_ori(self):
+        """
+        :return: Position [X,Y,Z] and orientation [X,Y,Z,W] of robot base.
+        :rtype: list[float], list[float]
+        """
+        return self._base_pose['position'], self._base_pose['orientation']

--- a/src/pybullet_robots/pybullet_robots/bullet_robot_description.py
+++ b/src/pybullet_robots/pybullet_robots/bullet_robot_description.py
@@ -5,7 +5,7 @@ import numpy as np
 class BulletRobotDescription(object):
     """
     Bullet Robot Description for a robotic manipulator (tested only with the Franka Panda).
-    This is a collection of methods that gather and store static information from the robot descritption urdf
+    This is a collection of methods that gather and store static information from the robot description urdf
     such that this information only has to be requested from the pybullet physics engine once.
 
     Available methods (for usage, see documentation at function definition):
@@ -87,10 +87,6 @@ class BulletRobotDescription(object):
                               for x in zip(self._joint_position_limits['lower'],
                                            self._joint_position_limits['upper'],
                                            self._joint_velocity_limits, self._joint_effort_limits)]
-
-        # # by default, set FT sensor at last fixed joint
-        # self._ft_joints = [self._all_joints[-1]]
-        # self.set_ft_sensor_at(self._ft_joints[0])
 
         self._base_pose = {}
         if config is not None:
@@ -366,9 +362,6 @@ class BulletRobotDescription(object):
         """
         Get default joint positions of all movable joints.
 
-        :param joint_positions: default joint positions of movable joints
-        :type joint_positions: list of float
-
         :return: Default joint positions or False if they have not been set yet
         :rtype: list of float
         """
@@ -385,7 +378,7 @@ class BulletRobotDescription(object):
         pb.resetBasePositionAndOrientation(
             self._id, self._base_pose['position'], self._base_pose['orientation'], physicsClientId=self._uid)
 
-    def get_base_pos_ori(self):
+    def get_base_pose(self):
         """
         :return: Position [X,Y,Z] and orientation [X,Y,Z,W] of robot base.
         :rtype: list[float], list[float]

--- a/src/pybullet_simulation/pybullet_simulation/simulation.py
+++ b/src/pybullet_simulation/pybullet_simulation/simulation.py
@@ -2,6 +2,15 @@ import pybullet as pb
 
 
 class Simulation(object):
+    """
+    The Simulation class creates the PyBullet physics server and GUI.
+
+    Available methods (for usage, see documentation at function definition):
+        - is_alive
+        - step
+        - add_robot_models_path
+        - add_PyB_models_path
+    """
 
     def __init__(self, realtime_sim=False, realtime_sim_freq=500.0):
         """

--- a/src/pybullet_simulation/pybullet_simulation/worlds/empty_world.py
+++ b/src/pybullet_simulation/pybullet_simulation/worlds/empty_world.py
@@ -15,6 +15,15 @@ class WorldObjects(object):
 
 
 class EmptyWorld(object):
+    """
+    The EmptyWorld class defines the objects in the simulation environment apart from the robot. Objects can be added
+    by their urdf and removed by their name given at creation.
+
+    Available methods (for usage, see documentation at function definition):
+        - add_object_from_urdf
+        - remove_objects
+        - add_PyB_models_path
+    """
 
     def __init__(self, uid, add_plane=False, gravity=[0, 0, -9.81]):
         """

--- a/tests/interface_test.py
+++ b/tests/interface_test.py
@@ -44,16 +44,11 @@ if __name__ == "__main__":
         # important to check that conventions (column-major/row-major, quaternion, twist
         # force/torque) are the same in the simulation interface (python) and the control (cpp)
         for i, key in enumerate(state):
-            if key == 'ee_ori':
+            if key == 'ee_orientation':
                 state[key].w = 1
                 state[key].x = 0
                 state[key].y = 0.5
                 state[key].z = 0
-            elif key == 'tip_state':
-                for j, key2 in enumerate(state[key]):
-                    state[key][key2] = (j + 1) * i * np.ones(state[key][key2].shape)
-                state[key]['force'][1] = 100.0
-                state[key]['torque'][2] = -100.0
             else:
                 state[key] = i * np.ones(state[key].shape)
                 if key == 'jacobian':

--- a/tests/interface_test.py
+++ b/tests/interface_test.py
@@ -19,18 +19,12 @@ if __name__ == "__main__":
 
     robot = PandaArm(robot_description=os.path.join(os.path.dirname(__file__), os.pardir, "models/panda_arm.urdf"),
                      uid=simulation.uid)
-    timeout = time.time() + 2
-    while time.time() < timeout:
-        robot.tuck()
-        simulation.step()
 
     print(robot._uid)
     print(robot._id)
-    print(robot._rt_sim)
     print(robot._all_joints)
     print(robot._movable_joints)
-    print(robot._nu)
-    print(robot._nq)
+    print(robot._nb_movable_joints)
     print(robot._all_joint_names)
     print(robot._all_joint_dict)
     print(robot._ee_link_idx)
@@ -44,7 +38,7 @@ if __name__ == "__main__":
     k = 0
     while simulation.is_alive():
         now = time.time()
-        state = robot.state()
+        state = robot.get_state()
 
         # set unique values in all fields to check integrity of the communication because it's
         # important to check that conventions (column-major/row-major, quaternion, twist

--- a/tests/robot_test.py
+++ b/tests/robot_test.py
@@ -18,6 +18,7 @@ if __name__ == "__main__":
     if not simulation.add_robot_models_path(os.path.join(os.path.dirname(__file__), os.pardir, "models")):
         exit(1)
     robot = BulletRobot(robot_urdf="panda_arm.urdf", enforce_joint_limits=True, uid=simulation.uid)
+    print(robot.get_joint_names())
     # Test some bullet_robot_description methods
     robot.set_default_joint_positions([-0.017792060227770554, -0.7601235411041661, 0.019782607023391807,
                                        -2.342050140544315, 0.029840531355804868, 1.5411935298621688,

--- a/tests/robot_test.py
+++ b/tests/robot_test.py
@@ -1,0 +1,67 @@
+from pybullet_simulation import Simulation
+from pybullet_simulation.worlds import EmptyWorld
+from pybullet_robots import BulletRobot
+import time
+import os.path
+
+if __name__ == "__main__":
+    desired_frequency = 500.0
+    # create simulation object
+    simulation = Simulation(realtime_sim=False, realtime_sim_freq=desired_frequency)
+
+    # load empty world and add table
+    world = EmptyWorld(uid=simulation.uid, add_plane=True, gravity=[0, 0, -9.81])
+    world.add_object_from_urdf('table', 'table/table.urdf', position_xyz=[0.4, 0, 0],
+                               orientation_wxyz=[0, 0, -0.707, 0.707], fixed_base=True, scaling=0.5)
+
+    # create robot after adding models path
+    if not simulation.add_robot_models_path(os.path.join(os.path.dirname(__file__), os.pardir, "models")):
+        exit(1)
+    robot = BulletRobot(robot_urdf="panda_arm.urdf", enforce_joint_limits=True, uid=simulation.uid)
+    # Test some bullet_robot_description methods
+    robot.set_default_joint_positions([-0.017792060227770554, -0.7601235411041661, 0.019782607023391807,
+                                       -2.342050140544315, 0.029840531355804868, 1.5411935298621688,
+                                       0.7534486589746342])
+    robot.set_enforce_joint_limits(False)
+    # print(robot.get_link_index_by_name('link')) # this raises an exception
+    print(robot.get_joint_index_by_name('panda_joint5'))
+    print(robot.get_joint_limits())
+    print(robot.get_default_joint_positions())
+
+    # Test some bullet_robot methods
+    robot.goto_default_joint_positions()
+    print(robot.disable())
+    print(robot.set_control_mode('test'))
+    print(robot.get_joint_positions())
+    print(robot.set_control_mode('position'))
+
+    robot.enable()
+    print(robot.goto_default_joint_positions())
+    time.sleep(2)
+    cmd_velocities = [0.1, 0, 0, 0, 0, 0, 0]
+    cmd_positions = [-0.017792060227770554, -0.7601235411041661, 0.519782607023391807, -2.342050140544315,
+                     0.029840531355804868, 1.9411935298621688, 0.7534486589746342]
+    start = time.time()
+    k = 0
+    while simulation.is_alive():
+        now = time.time()
+        if robot.enabled:
+            state = robot.get_state()
+            if k < 2000 and robot.check_robot_state(state):
+                robot.set_joint_positions_cmd(cmd_positions)
+            elif k == 2000 and robot.check_robot_state(state):
+                robot.disable()
+                robot.goto_default_joint_positions()
+                robot.set_control_mode('velocity')
+                robot.enable()
+                robot.set_enforce_joint_limits(True)
+            elif k > 2000 and robot.check_robot_state(state):
+                robot.set_joint_velocities_cmd(cmd_velocities)
+        simulation.step()
+
+        elapsed = time.time() - now
+        sleep_time = (1. / desired_frequency) - elapsed
+        if sleep_time > 0.0:
+            time.sleep(sleep_time)
+        k = k + 1
+        # print("Average rate: ", k / (time.time() - start))

--- a/tests/velocity_control_test.py
+++ b/tests/velocity_control_test.py
@@ -1,0 +1,59 @@
+from pybullet_simulation import Simulation
+from pybullet_simulation.worlds import EmptyWorld
+from pybullet_robots import BulletRobot
+import time
+from pybullet_interfaces.franka_zmq_simulation_interface import FrankaZMQSimulationInterface
+import os.path
+
+if __name__ == "__main__":
+    # create interface with default state_uri and command_uri
+    interface = FrankaZMQSimulationInterface()
+
+    desired_frequency = 500.0
+    # create simulation object
+    simulation = Simulation(realtime_sim=False, realtime_sim_freq=desired_frequency)
+
+    # load empty world and add table
+    world = EmptyWorld(uid=simulation.uid, add_plane=True, gravity=[0, 0, -9.81])
+    world.add_object_from_urdf('table', 'table/table.urdf', position_xyz=[0.4, 0, 0],
+                               orientation_wxyz=[0, 0, -0.707, 0.707], fixed_base=True, scaling=0.5)
+
+    # create robot after adding models path
+    if not simulation.add_robot_models_path(os.path.join(os.path.dirname(__file__), os.pardir, "models")):
+        exit(1)
+    robot = BulletRobot(robot_urdf="panda_arm.urdf", enforce_joint_limits=False, uid=simulation.uid)
+    # Test some bullet_robot_description methods
+    robot.set_default_joint_positions([-0.017792060227770554, -0.7601235411041661, 0.019782607023391807,
+                                       -2.342050140544315, 0.029840531355804868, 1.5411935298621688,
+                                       0.7534486589746342])
+    robot.goto_default_joint_positions()
+    robot.set_control_mode('velocity')
+    robot.enable()
+
+    time.sleep(1)
+    command = [0, 0, 0, 0, 0, 0, 0]
+    first_command_received = False
+    recent_command_time = 0.0
+    start = time.time()
+    k = 0
+    while simulation.is_alive():
+        now = time.time()
+        state = robot.get_state()
+
+        interface.send(state)
+        interface.poll_command()
+        if interface.first_message_received:
+            if interface.timeout_triggered:
+                robot.disable()
+            else:
+                robot.set_joint_velocities_cmd(interface.current_command)
+
+        simulation.step()
+
+        elapsed = time.time() - now
+        sleep_time = (1. / desired_frequency) - elapsed
+        if sleep_time > 0.0:
+            time.sleep(sleep_time)
+        k = k + 1
+
+        # print("Average rate: ", k / (time.time() - start))


### PR DESCRIPTION
This PR includes the following important commits:
-  Refactoring of the BulletRobot class:

    The BulletRobot class is split into two classes, BulletRobotDescription and BulletRobot.
    The former loads all relevant information about the robot from the urdf and stores this information
    when the object is created, wheareas the latter implements methods that are required during the
    actual simulation, e.g. getting the robot state, set the control method, and set the joint
    commands, as well as a few saftey methods for checking joint limits, enabling/disabling the
    robot, and triggering an emergency stop.
    
    These methods are tested in robot_test.py.
    
    The robot specfic PandaArm class loses importance because most methods are implemented in
    BulletRobot and BulletRobotDescription. This class might be replaced with a simple config file in
    the future. Or, it might regain importance if we see that different types of robots do require
    different methods and classes. It is for now left there to be backwards compatible with the demo
    scripts. However, technically, this class is not needed for the simulation of a panda robot.

-  Make necessary changes to adapt to bullet_robot refactoring:
    
    These changes ensure backward compatibility with the demos from the original code.
    It's useful to check that these demos still have the same behavior to ensure that the
    refactoring isn't a breaking change.
    
    However, it's important to note that these are minimal changes and not all the available
    methods are considered, so it might happen that unused methods break the code. This is
    acceptable given the fact that this is a development process and that the demos use the
    simualtion in a slightly different way that it is intended here.

-  Add example script to run a simulation with velocity control:
    
    The velocity_control_test.py script shows how the simulation is supposed to be structured.
    First, the interface, simulation, world, and robot are created and set to the desired state.
    Then, the simulation is waiting to accept commands over the interface and applies those until
    the connection is broken.
    
    This certainly works for joint position and velocity control. Torque control does not work yet
    but will be the very next step.

This is quite a big PR but I believe it's a good step in the right direction. Everything is still under development and most important next steps are: 
- Make torque control work with the zmq interface
- Draw lines and frames in the GUI, enable logging of robot state and similar

Other things that remain on my TODO list and are optional:
- Exploit threading
- Make proper tests (unittest)
- Handle exceptions better, use logger instead of print method
- interactive GUI